### PR TITLE
Remove transparent background from btn-default

### DIFF
--- a/src/less/uw-ui-toolkit/my-uw/buttons.less
+++ b/src/less/uw-ui-toolkit/my-uw/buttons.less
@@ -20,7 +20,7 @@
   padding:2px 5px;
 }
 .btn-default {
-  background-color:transparent;
+  //background-color:transparent;
   color: #222;
   box-shadow: 0px 2px 0px #ccc;
   border: 1px solid #ddd;


### PR DESCRIPTION
Having a transparent background on the btn-default causes the active state to not apply it's background.
